### PR TITLE
Resolving Issue 2191 - log_submit now validates for date

### DIFF
--- a/app/controllers/assessment/handin.rb
+++ b/app/controllers/assessment/handin.rb
@@ -270,6 +270,13 @@ module AssessmentHandin
       render(plain: err, status: :bad_request) && return
     end
 
+    # Validate assessment dates
+    current_time = Time.current
+    if current_time < @assessment.start_at || current_time > @assessment.end_at
+      err = "ERROR: Submissions are not allowed outside the assessment period"
+      render(plain: err, status: :bad_request) && return
+    end
+
     @result = params[:result]
     render(plain: "ERROR: No result!", status: :bad_request) && return unless @result
 

--- a/spec/controllers/assessments_controller_spec.rb
+++ b/spec/controllers/assessments_controller_spec.rb
@@ -212,4 +212,99 @@ RSpec.describe AssessmentsController, type: :controller do
       end
     end
   end
+
+  describe "log_submit" do
+    context "when the date is inside of the assessment period" do
+      let!(:course_hash) { create_course_with_users_as_hash }
+      let!(:valid_assessment) do
+        assessment_path = Rails.root.join("courses/#{course_hash[:course].name}/assessment_valid")
+        FileUtils.mkdir_p(assessment_path)
+        FileUtils.mkdir_p("#{assessment_path}/handin")
+        assessment = FactoryBot.create(:assessment,
+                                        name: "assessment_valid",
+                                        course: course_hash[:course],
+                                        start_at: 2.days.ago,
+                                        due_at: 1.day.from_now,
+                                        end_at: 2.days.from_now,
+                                        allow_unofficial: true)
+        assessment.save!
+        assessment
+      end
+  
+      it "allows a valid log submission" do
+        user = course_hash[:students_cud].first
+        params = {
+          course_name: course_hash[:course].name,
+          name: valid_assessment.name,
+          user: user.email,
+          result: "test result"
+        }
+        post :log_submit, params: params
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq("OK")
+      end
+    end
+  
+    context "when the submission is before the start date" do
+      let!(:course_hash) { create_course_with_users_as_hash }
+      let!(:invalid_assessment) do
+        assessment_path = Rails.root.join("courses/#{course_hash[:course].name}/assessment_invalid_date")
+        FileUtils.mkdir_p(assessment_path)
+        FileUtils.mkdir_p("#{assessment_path}/handin")
+        assessment = FactoryBot.create(:assessment,
+                                        name: "assessment_invalid_date",
+                                        course: course_hash[:course],
+                                        start_at: 1.day.from_now,
+                                        due_at: 2.days.from_now,
+                                        end_at: 3.days.from_now,
+                                        allow_unofficial: true)
+        assessment.save!
+        assessment
+      end
+  
+      it "rejects a log submission for having invalid dates" do
+        user = course_hash[:students_cud].first
+        params = {
+          course_name: course_hash[:course].name,
+          name: invalid_assessment.name,
+          user: user.email,
+          result: "test result"
+        }
+        post :log_submit, params: params
+        expect(response).to have_http_status(:bad_request)
+        expect(response.body).to eq("ERROR: Submissions are not allowed outside the assessment period")
+      end
+    end
+
+    context "when the submission is after the end date" do
+      let!(:course_hash) { create_course_with_users_as_hash }
+      let!(:expired_assessment) do
+        assessment_path = Rails.root.join("courses/#{course_hash[:course].name}/assessment_expired")
+        FileUtils.mkdir_p(assessment_path)
+        FileUtils.mkdir_p("#{assessment_path}/handin")
+        assessment = FactoryBot.create(:assessment,
+                                        name: "assessment_expired",
+                                        course: course_hash[:course],
+                                        start_at: 3.days.ago,
+                                        due_at: 2.days.ago,
+                                        end_at: 1.day.ago,
+                                        allow_unofficial: true)
+        assessment.save!
+        assessment
+      end
+    
+      it "rejects a log submission for having invalid dates" do
+        user = course_hash[:students_cud].first
+        params = {
+          course_name: course_hash[:course].name,
+          name: expired_assessment.name,
+          user: user.email,
+          result: "test result"
+        }
+        post :log_submit, params: params
+        expect(response).to have_http_status(:bad_request)
+        expect(response.body).to eq("ERROR: Submissions are not allowed outside the assessment period")
+      end
+    end
+  end
 end


### PR DESCRIPTION
The new additions add additional validation tot he log_submit functionality for assessments. Now, the dates are checked for validity before submitting.

## Description
This pull requests has modified the log_submit method in the AssessmentsController to ensure that no assessments are being submitted without proper date validation. The code checks if the current time is before the start time of the assessment, or if the current time is beyond the end time of the assessment. If either condition is met, and error is thrown. This pull request addresses pull request number 2191. This pull request suggests on potential solution: " One possibly elegant way to do this is to create a new Submission object (but never save it). If the submission would be allowed? then it's ok to record the log entry, otherwise it should be refused." This option was initially explored. However, given the brevity of the fix, it was determined that creating a new object would likely serve to confuse and further complicate the functionality. And since the original log_submit function already has certain validations and checks, adding the date check only made sense.

## Motivation and Context
The motivation for this pull request is to address an issue brought up, linked here: https://github.com/autolab/Autolab/issues/2191
With these changes, the proper checks will be ran for proper code quality and coverage.

## How Has This Been Tested?
Accompanied by these code changes are several new tests, which have been added to the AssessmentController test suite found here: spec/controllers/assessments_controller_spec.rb. Three new tests have been added. The first executes the log_submit functionality with validated dates. The second attempts to do the same but with the submittion date before the start date of the assessment. Lastly, the third test seeks to do the same but with a submission date after the end date. As expected, the original code causes the first test to pass, but the last two to fail. With the code change, all three tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x ] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

